### PR TITLE
Pass the input map correctly to run_higher_sph_harm

### DIFF
--- a/run_higher_sph_harm.py
+++ b/run_higher_sph_harm.py
@@ -83,7 +83,7 @@ def run_lc_noise_and_fit(norder=3,
         # ### Add Noise
 
         # In[12]:
-        inputLC3D = add_noise.get_lc()
+        inputLC3D = add_noise.get_lc(inputFile=usePath)
         noiseDict = add_noise.add_noise(inputLC3D)
 
 


### PR DESCRIPTION
Found out why Megan and I were not getting the quadrant maps correctly processed by run_higher_sph_harm and were instead getting results that looked like the hot spot model. Now the path is correctly passed on to `add_noise.get_lc()`
