### PR TITLE
Fixed bug that flipped quadrant designations relative to docs

### DIFF
--- a/gen_lightcurves.py
+++ b/gen_lightcurves.py
@@ -427,7 +427,7 @@ def create_quadrant_map(f1, f2, f3, f4, lat0 = 0.0, lon0 = 0.0, Nside = 16):
 
     # Calc the latitude and longitude of each hpix
     thetas, phis = hp.pix2ang(Nside, np.arange(Npix), lonlat=True)
-    # Latitudes are the phis 
+    # Latitudes are the phis
     lat = phis
     # Convert to west (0 to -180) and east (0 to +180) longitudes
     lon = (thetas - 180.0)
@@ -435,8 +435,6 @@ def create_quadrant_map(f1, f2, f3, f4, lat0 = 0.0, lon0 = 0.0, Nside = 16):
     # Define empty 2d array for spaxels
     Nlam = len(f1)
     spaxels = np.zeros((Npix, Nlam))
-
-    import pdb; pdb.set_trace()
 
     # Loop over pixels filling with spectra
     for i in range(Npix):

--- a/gen_lightcurves.py
+++ b/gen_lightcurves.py
@@ -426,42 +426,46 @@ def create_quadrant_map(f1, f2, f3, f4, lat0 = 0.0, lon0 = 0.0, Nside = 16):
     Npix = hp.nside2npix(Nside)
 
     # Calc the latitude and longitude of each hpix
-    thetas, phis = hp.pix2ang(Nside, np.arange(Npix))
-    lat = (thetas - np.pi / 2) * 180 / np.pi
-    lon = (phis - np.pi) * 180 / np.pi
+    thetas, phis = hp.pix2ang(Nside, np.arange(Npix), lonlat=True)
+    # Latitudes are the phis 
+    lat = phis
+    # Convert to west (0 to -180) and east (0 to +180) longitudes
+    lon = (thetas - 180.0)
 
     # Define empty 2d array for spaxels
     Nlam = len(f1)
     spaxels = np.zeros((Npix, Nlam))
 
-    # Loop over pixels filling with blackbody
+    import pdb; pdb.set_trace()
+
+    # Loop over pixels filling with spectra
     for i in range(Npix):
 
-        # Latitudes greater than demarcation
+        # Latitudes north of demarcation
         if (lat[i] > lat0):
 
-            # Longitudes greater than demarcation
-            if (lon[i] > lon0):
+            # Longitudes west of demarcation
+            if (lon[i] < lon0):
 
                 # Set flux 1
                 spaxels[i,:] = f1
 
-            # Longitudes less than demarcation
+            # Longitudes east of demarcation
             else:
 
                 # Set flux 2
                 spaxels[i,:] = f2
 
-        # Latitudes less than demarcation
+        # Latitudes south of demarcation
         else:
 
-            # Longitudes greater than demarcation
-            if (lon[i] > lon0):
+            # Longitudes west of demarcation
+            if (lon[i] < lon0):
 
                 # Set flux 3
                 spaxels[i,:] = f3
 
-            # Longitudes less than demarcation
+            # Longitudes east of demarcation
             else:
 
                 # Set flux 4


### PR DESCRIPTION
@meganmansfield discovered this bug, which manifested as a mismatch between expected quadrant fluxes based on my descriptions in the docs and the true quadrant fluxes painted on the map when viewed with starry. Fortunately, this bug was just a silly North-South latitude flip and an East-West longitude flip. It is now fixed and the code should be operating in agreement with the doc strings. Specifically, the function `create_quadrant_map(f1, f2, f3, f4, lat0 = 0.0, lon0 = 0.0, Nside = 16)` returns a quadrant map with different spectra "painted on the surface", where the input spectra are: 

```
    f1 : array
        Planet-star flux ratio 1 (upper/north left/west)
    f2 : array
        Planet-star flux ratio 2 (lower/south left/west)
    f3 : array
        Planet-star flux ratio 3 (upper/north right/east)
    f4 : array
        Planet-star flux ratio 4 (lower/south right/east)
```